### PR TITLE
Added support for node-gossip to be run from within a project's directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.sw?
+node_modules

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Check out the the scripts in the simulations/ directory for some examples.
 
 Gossiper methods:
 
-    allPeeers()
+    allPeers()
     livePeers()
     deadPeers()
     peerValue(peer, key)

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+// This file is just added for convenience so this repository can be
+// directly checked out (submodule)  into a project
+module.exports = require('./lib/gossiper');

--- a/lib/gossiper.js
+++ b/lib/gossiper.js
@@ -12,6 +12,7 @@ var Gossiper = exports.Gossiper = function(port, seeds, ip_to_bind) {
   this.peers    = {};
   this.ip_to_bind     = ip_to_bind;
   this.port     = port;
+  this.seeds    = seeds;
   this.my_state = new PeerState();
   this.scuttle  = new Scuttle(this.peers, this.my_state);
 
@@ -63,12 +64,12 @@ Gossiper.prototype.stop = function() {
 }
 
 
-// The method of choosing whice peer(s) to gossip to is borrowed from Cassandra.
+// The method of choosing which peer(s) to gossip to is borrowed from Cassandra.
 // They seemed to have worked out all of the edge cases
 // http://wiki.apache.org/cassandra/ArchitectureGossip
 Gossiper.prototype.gossip = function() {
   // Find a live peer to gossip to
-  if(this.livePeers() > 0) {
+  if(this.livePeers().length > 0) {
     var live_peer = this.chooseRandom(this.livePeers());
     this.gossipToPeer(live_peer);
   }
@@ -219,12 +220,12 @@ Gossiper.prototype.allPeers = function() {
 
 Gossiper.prototype.livePeers = function() {
   var keys = [];
-  for(var k in this.peers) { if(k.alive) { keys.push(k)} };
+  for(var k in this.peers) { if(this.peers[k].alive) { keys.push(k)} };
   return keys;
 }
 
 Gossiper.prototype.deadPeers = function() {
   var keys = [];
-  for(var k in this.peers) { if(!k.alive) { keys.push(k) } };
+  for(var k in this.peers) { if(!this.peers[k].alive) { keys.push(k) } };
   return keys;
 }

--- a/lib/gossiper.js
+++ b/lib/gossiper.js
@@ -1,11 +1,11 @@
-var PeerState = require('./peer_state').PeerState,
-    Scuttle = require('./scuttle').Scuttle,
-    EventEmitter = require('events').EventEmitter,
-    net          = require('net'), 
-    sys          = require('sys'),
+var PeerState     = require('./peer_state').PeerState,
+    Scuttle       = require('./scuttle').Scuttle,
+    EventEmitter  = require('events').EventEmitter,
+    net           = require('net'), 
+    util          = require('util'),
     child_process = require('child_process'),
-    dns         = require('dns'),
-    msgpack     = require('msgpack'); 
+    dns           = require('dns'),
+    msgpack       = require('msgpack'); 
 
 var Gossiper = exports.Gossiper = function(port, seeds, ip_to_bind) {
   EventEmitter.call(this);
@@ -19,7 +19,7 @@ var Gossiper = exports.Gossiper = function(port, seeds, ip_to_bind) {
   this.handleNewPeers(seeds);
 }
 
-sys.inherits(Gossiper, EventEmitter);
+util.inherits(Gossiper, EventEmitter);
 
 Gossiper.prototype.start = function(callback) {
   var self = this;
@@ -113,7 +113,7 @@ Gossiper.prototype.gossipToPeer = function(peer) {
     mp_stream.send(self.requestMessage());
   });
   gosipee.on('error', function(exception) {
-//    console.log(self.peer_name + " received " + sys.inspect(exception));
+//    console.log(self.peer_name + " received " + util.inspect(exception));
   });
 }
 

--- a/lib/gossiper.js
+++ b/lib/gossiper.js
@@ -1,5 +1,5 @@
-var PeerState = require('peer_state').PeerState,
-    Scuttle = require('scuttle').Scuttle,
+var PeerState = require('./peer_state').PeerState,
+    Scuttle = require('./scuttle').Scuttle,
     EventEmitter = require('events').EventEmitter,
     net          = require('net'), 
     sys          = require('sys'),

--- a/lib/peer_state.js
+++ b/lib/peer_state.js
@@ -1,6 +1,6 @@
-var AccrualFailureDetector = require('./accrual_failure_detector').AccrualFailureDetector,
-    EventEmitter = require('events').EventEmitter,
-    sys          = require('sys'); 
+var AccrualFailureDetector  = require('./accrual_failure_detector').AccrualFailureDetector,
+    EventEmitter            = require('events').EventEmitter,
+    util                    = require('util'); 
 
 var PeerState = exports.PeerState = function(name) {
   EventEmitter.call(this);
@@ -13,7 +13,7 @@ var PeerState = exports.PeerState = function(name) {
   this.name             = name;
 };
 
-sys.inherits(PeerState, EventEmitter);
+util.inherits(PeerState, EventEmitter);
 
 PeerState.prototype.updateWithDelta = function(k,v,n) {
   // It's possibly to get the same updates more than once if we're gossiping with multiple peers at once

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gossiper",
   "description": "node-gossip implements a gossip protocol",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "Bob Potter <bobby.potter@gmail.com>",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,9 @@
 {
   "name": "gossiper",
   "description": "node-gossip implements a gossip protocol",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "Bob Potter <bobby.potter@gmail.com>",
   "contributors": [
-    {
-      "name": "Bob Potter",
-      "email": "bobby.potter@gmail.com"
-    }, 
     {
       "name": "Christopher Mooney",
       "email": "chris@dod.net"
@@ -19,7 +15,7 @@
   },
   "keywords": ["gossip"],
   "dependencies": {
-    "msgpack"     : "git://github.com/godsflaw/node-msgpack.git"
+    "msgpack"     : ">= 0.0.0"
   },
   "main": "index.js",
   "scripts": { "test": "expresso -I lib test/*" },

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "node-gossip",
+  "description": "node-gossip implements a gossip protocol",
+  "version": "0.0.1",
+  "author": "Bob Potter <bobby.potter@gmail.com>",
+  "contributors": [
+    {
+      "name": "Bob Potter",
+      "email": "bobby.potter@gmail.com"
+    }, 
+    {
+      "name": "Christopher Mooney",
+      "email": "chris@dod.net"
+    }
+  ],
+  "repository": {
+    "type" : "git",
+    "url"  : "git://github.com/bpot/node-gossip.git" 
+  },
+  "keywords": ["gossip"],
+  "dependencies": {
+    "msgpack"     : "git://github.com/godsflaw/node-msgpack.git"
+  },
+  "main": "index.js",
+  "scripts": { "test": "expresso -I lib test/*" },
+  "engines": { "node": "0.4.x || 0.5.x || 0.6.x || 0.7.x" }
+}

--- a/package.json
+++ b/package.json
@@ -23,5 +23,5 @@
   },
   "main": "index.js",
   "scripts": { "test": "expresso -I lib test/*" },
-  "engines": { "node": "0.4.x || 0.5.x || 0.6.x || 0.7.x" }
+  "engines": { "node": "0.4.x || 0.5.x || 0.6.x || 0.7.x || 0.8.x || 0.9.x" }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-gossip",
+  "name": "gossiper",
   "description": "node-gossip implements a gossip protocol",
   "version": "0.0.1",
   "author": "Bob Potter <bobby.potter@gmail.com>",

--- a/simulation/s3.js
+++ b/simulation/s3.js
@@ -1,5 +1,4 @@
 var Gossiper = require('gossiper').Gossiper;
-var sys = require('sys');
 
 var seed1 = new Gossiper(9000, []);
 seed1.start();


### PR DESCRIPTION
Added support for node-gossip to be run from within a project's directory.  This means that one can use git submodule to install it. I was unable to get the tests working because a require path problem. This problem was so bad I can only assume my environment is incorrect for running expresso tests.  Please run tests and make sure they work.

I also pushed some pull requests to fix node-msgpack.  I will let you know if I run into problems playing with node-gossip.
