### PR TITLE
Fix unit tests failing

### DIFF
--- a/lib/gossiper.js
+++ b/lib/gossiper.js
@@ -1,11 +1,11 @@
 var PeerState     = require('./peer_state').PeerState,
     Scuttle       = require('./scuttle').Scuttle,
     EventEmitter  = require('events').EventEmitter,
-    net           = require('net'), 
+    net           = require('net'),
     util          = require('util'),
     child_process = require('child_process'),
     dns           = require('dns'),
-    msgpack       = require('msgpack'); 
+    msgpack       = require('msgpack');
 
 var Gossiper = exports.Gossiper = function(port, seeds, ip_to_bind) {
   EventEmitter.call(this);
@@ -32,13 +32,13 @@ Gossiper.prototype.start = function(callback) {
 
   // Bind to ip/port
   if(this.ip_to_bind) {
-    this.peer_name    = [this.address, this.port.toString()].join(':');
+    this.peer_name    = [this.ip_to_bind, this.port.toString()].join(':');
     this.peers[this.peer_name] = this.my_state;
     this.my_state.name = this.peer_name;
     this.server.listen(this.port, this.ip_to_bind, callback);
   } else {
     // this is an ugly hack to get the hostname of the local machine
-    // we don't listen on any ip because it's important that we listen 
+    // we don't listen on any ip because it's important that we listen
     // on the same ip that the server identifies itself as
     child_process.exec('hostname', function(error, stdout, stderr) {
       var l = stdout.length;

--- a/lib/gossiper.js
+++ b/lib/gossiper.js
@@ -32,7 +32,7 @@ Gossiper.prototype.start = function(callback) {
 
   // Bind to ip/port
   if(this.ip_to_bind) {
-    this.peer_name    = [this.ip_to_bind, this.port.toString()].join(':');
+    this.peer_name    = [this.address, this.port.toString()].join(':');
     this.peers[this.peer_name] = this.my_state;
     this.my_state.name = this.peer_name;
     this.server.listen(this.port, this.ip_to_bind, callback);

--- a/package.json
+++ b/package.json
@@ -7,17 +7,30 @@
     {
       "name": "Christopher Mooney",
       "email": "chris@dod.net"
+    },
+    {
+      "name": "Angelo Rodrigues",
+      "email": "xangelo@gmail.com"
     }
   ],
   "repository": {
-    "type" : "git",
-    "url"  : "git://github.com/bpot/node-gossip.git" 
+    "type": "git",
+    "url": "git://github.com/bpot/node-gossip.git"
   },
-  "keywords": ["gossip"],
+  "keywords": [
+    "gossip"
+  ],
   "dependencies": {
-    "msgpack"     : ">= 0.0.0"
+    "msgpack": ">= 0.0.0"
   },
   "main": "index.js",
-  "scripts": { "test": "expresso -I lib test/*" },
-  "engines": { "node": "0.4.x || 0.5.x || 0.6.x || 0.7.x || 0.8.x || 0.9.x" }
+  "scripts": {
+    "test": "expresso -I lib test/*"
+  },
+  "engines": {
+    "node": "0.4.x || 0.5.x || 0.6.x || 0.7.x || 0.8.x || 0.9.x"
+  },
+  "devDependencies": {
+    "expresso": "^0.9.2"
+  }
 }

--- a/test/accrual_failure_detector.test.js
+++ b/test/accrual_failure_detector.test.js
@@ -1,7 +1,8 @@
-var AccrualFailureDetector = require('accrual_failure_detector').AccrualFailureDetector;
+var AccrualFailureDetector = require(__dirname + '/../lib/accrual_failure_detector').AccrualFailureDetector,
+    assert = require('assert');
 
 module.exports = {
-  'should have a low phi value after only a second' : function(assert) {
+  'should have a low phi value after only a second' : function(beforeExit) {
     var afd = new AccrualFailureDetector();
     var time = 0;
     for(var i = 0;i < 100;i++) {
@@ -11,7 +12,7 @@ module.exports = {
     assert.ok(afd.phi(time + 1000) < 0.5);
   },
 
-  'should have a high phi value after ten seconds' : function(assert) {
+  'should have a high phi value after ten seconds' : function(beforeExit) {
     var afd = new AccrualFailureDetector();
     var time = 0;
     for(var i = 0;i < 100;i++) {
@@ -21,7 +22,7 @@ module.exports = {
     assert.ok(afd.phi(time + 10000) > 4);
   },
 
-  'should only keep last 1000 values' : function(assert) {
+  'should only keep last 1000 values' : function(beforeExit) {
     var afd = new AccrualFailureDetector();
     var time = 0;
     for(var i = 0;i < 2000;i++) {

--- a/test/gossiper.test.js
+++ b/test/gossiper.test.js
@@ -1,32 +1,33 @@
-var Gossiper = require('gossiper').Gossiper,
-    PeerState = require('peer_state').PeerState;
+var Gossiper = require(__dirname + '/../lib/gossiper').Gossiper,
+    PeerState = require(__dirname + '/../lib/peer_state').PeerState,
+    assert = require('assert');
 
 module.exports = {
-  'should be able to set and retrieve local state' : function(assert) {
+  'should be able to set and retrieve local state' : function(beforeExit) {
     var g = new Gossiper();
     g.setLocalState('hi', 'hello');
-    assert.equal('hello', g.getLocalState('hi'));
+    assert.eql('hello', g.getLocalState('hi'));
   },
-  'should be able to get a list of keys for a peer' : function(assert) {
+  'should be able to get a list of keys for a peer' : function(beforeExit) {
     var g = new Gossiper();
     g.peers['p1'] = new PeerState();
     g.peers['p1'].attrs['keyz'] = [];
     g.peers['p1'].attrs['keyzy'] = [];
     assert.deepEqual(['keyz','keyzy'], g.peerKeys('p1'));
   },
-  'should be able to get the value of a key for a peer' : function(assert) {
+  'should be able to get the value of a key for a peer' : function(beforeExit) {
     var g = new Gossiper();
     g.peers['p1'] = new PeerState();
     g.peers['p1'].attrs['keyz'] = ['hi', 1];
     assert.equal('hi', g.peerValue('p1','keyz'));
   },
-  'should be able to get a list of peers' : function(assert) {
+  'should be able to get a list of peers' : function(beforeExit) {
     var g = new Gossiper();
     g.peers['p1'] = new PeerState();
     g.peers['p2'] = new PeerState();
     assert.deepEqual(['p1','p2'], g.allPeers());
   },
-  'should emit new_peer event when we learn about a new peer' : function(assert, beforeExit) {
+  'should emit new_peer event when we learn about a new peer' : function(beforeExit) {
     var g = new Gossiper();
     // mock scuttle
     g.scuttle = { 'scuttle' : function(v) {
@@ -42,7 +43,7 @@ module.exports = {
       assert.ok(emitted);
     });
   },
-  'should emit update event when we learn more about a peer' : function(assert, beforeExit) {
+  'should emit update event when we learn more about a peer' : function(beforeExit) {
     var g = new Gossiper();
     g.peers['127.0.0.1:8010'] = new PeerState();
     g.handleNewPeers(['127.0.0.1:8010']);

--- a/test/peer_state.test.js
+++ b/test/peer_state.test.js
@@ -1,20 +1,22 @@
-var PeerState = require('peer_state').PeerState;
+var PeerState = require(__dirname + '/../lib/peer_state').PeerState,
+    assert = require('assert');
+
 module.exports = {
   // UpdateWithDelta
-  "updateWithDelta should set key to value" : function(assert) {
+  "updateWithDelta should set key to value" : function() {
     var ps = new PeerState();
     ps.updateWithDelta('a', 'hello', 12);
     assert.equal('hello', ps.getValue('a'));
   },
 
-  "updateWithDelta should update the max version" : function(assert) {
+  "updateWithDelta should update the max version" : function() {
     var ps = new PeerState();
     ps.updateWithDelta('a', 'hello', 12);
     ps.updateWithDelta('a', 'hello', 14);
     assert.equal(14, ps.max_version_seen);
   },
 
-  "updates should trigger 'update' event" : function(assert, beforeExit) {
+  "updates should trigger 'update' event" : function(beforeExit) {
     var ps = new PeerState();
     var n = 0;
     ps.on('update', function(k,v) {
@@ -27,13 +29,13 @@ module.exports = {
   },
 
   // updateLocal
-  "updateLocal should set key to value" : function(assert) {
+  "updateLocal should set key to value" : function() {
     var ps = new PeerState();
     ps.updateLocal('a', 'hello', 12);
     assert.equal('hello', ps.getValue('a'));
   },
 
-  "updateLocal should increment the max version" : function(assert) {
+  "updateLocal should increment the max version" : function() {
     var ps = new PeerState();
     ps.updateLocal('a', 'hello');
     ps.updateLocal('a', 'hello');
@@ -41,7 +43,7 @@ module.exports = {
   },
 
   // deltasAfterVersion
-  "deltasAfterVersion should return all deltas after a version number" : function(assert) {
+  "deltasAfterVersion should return all deltas after a version number" : function() {
     var ps = new PeerState();
     ps.updateLocal('a', 1);
     ps.updateLocal('b', 'blah');

--- a/test/scuttle.test.js
+++ b/test/scuttle.test.js
@@ -1,9 +1,10 @@
-var Scuttle = require('scuttle').Scuttle;
-var PeerState = require('peer_state').PeerState;
+var Scuttle = require(__dirname + '/../lib/scuttle').Scuttle,
+    PeerState = require(__dirname + '/../lib/peer_state').PeerState,
+    assert = require('assert');
 
 module.exports = {
   // digest
-  'digest should have max versions we have seen' : function(assert) {
+  'digest should have max versions we have seen' : function() {
     var p1 = new PeerState();
     p1.max_version_seen = 10;
     var p2 = new PeerState();
@@ -24,25 +25,25 @@ module.exports = {
 
   // scuttle
   // scuttle new peer
-  'new peers should be in result' : function(assert) {
+  'new peers should be in result' : function() {
     var scuttle = new Scuttle({});
-    var res = scuttle.scuttle( { 'new_peer' : 12 } ) 
+    var res = scuttle.scuttle( { 'new_peer' : 12 } )
     assert.deepEqual(['new_peer'], res.new_peers);
   },
-  'request all information about a new peer' : function(assert) {
+  'request all information about a new peer' : function() {
     var scuttle = new Scuttle({});
-    var res = scuttle.scuttle( { 'new_peer' : 12 } ) 
+    var res = scuttle.scuttle( { 'new_peer' : 12 } )
     assert.deepEqual({ 'new_peer' : 0}, res.requests);
   },
   // scuttle deltas
-  'send peer all deltas for peers we know more about' : function(assert) {
+  'send peer all deltas for peers we know more about' : function() {
     var p1 = new PeerState();
     p1.updateLocal('hi', 'hello');
     p1.updateLocal('meh', 'goodbye');
     var scuttle = new Scuttle({'me' : p1});
-    var res = scuttle.scuttle( {'me' : 0, 'new_peer' : 12 } ) 
+    var res = scuttle.scuttle( {'me' : 0, 'new_peer' : 12 } )
     assert.deepEqual([['me', 'hi', 'hello', 1],
-                      ['me', 'meh', 'goodbye', 2]], 
+                      ['me', 'meh', 'goodbye', 2]],
                      res.deltas);
   }
 


### PR DESCRIPTION
This PR fixes an issue with unit tests not running properly. 
- Includes expresso as a dev-dependency for easy exclusion in production installation
- Updates all unit tests to run on expresso
- Removes reliance on expresso specific assert mechanism, defaulting to node.js asserts.
